### PR TITLE
Initialize digital chip design repository structure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,24 @@
+# Simulation outputs
+sim/logs/
+sim/runs/
+sim/waves/
+*.vcd
+*.fsdb
+*.wlf
+
+# Build artifacts
+build/
+out/
+dist/
+*.d
+*.o
+
+# Python virtual environments
+.venv/
+__pycache__/
+*.pyc
+
+# Tool-specific directories
+.DS_Store
+.vscode/
+.idea/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,36 @@
+# Contributing Guidelines
+
+Thank you for your interest in contributing to this digital chip design repository. The guidelines below help maintain consistency and quality across the project.
+
+## Workflow
+
+1. Fork the repository or create a feature branch.
+2. Make incremental commits with clear and descriptive messages.
+3. Ensure simulations, lint checks, and other relevant flows pass before submitting changes.
+4. Open a pull request and request reviews from maintainers.
+
+## Coding Standards
+
+- Prefer synthesizable, well-documented RTL in the `rtl/` directory.
+- Follow the coding style defined in `docs/design_guidelines.md`.
+- Include self-checking testbenches under `tb/` whenever possible.
+- Keep scripts idempotent and provide usage instructions in headers or README files.
+
+## Documentation
+
+- Update `docs/` whenever architecture or interfaces change.
+- Document new scripts and flows in `scripts/README.md`.
+- Record assumptions, dependencies, and limitations alongside the relevant files.
+
+## Commit Messages
+
+- Use the present tense and describe what the change does.
+- Reference issue numbers where applicable.
+- Include additional context in the body when needed.
+
+## Code Review
+
+- Be open to feedback and iterate on review comments promptly.
+- Provide rationale for design decisions to help reviewers understand the implementation.
+
+By following these guidelines, we ensure a maintainable and collaborative environment for chip design development.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,28 @@
-# rv32_test
+# RV32 Digital Chip Design Repository
+
+This repository provides a clean starting point for RV32-class digital chip design projects. It organizes the typical assets required for RTL development, verification, and documentation so that new projects can begin with a clear structure.
+
+## Repository Layout
+
+- `rtl/` – Synthesizable RTL implementations of the core and peripheral blocks.
+- `tb/` – Testbenches, verification components, and stimulus generators.
+- `sim/` – Simulation configuration files, wave scripts, and regression setups.
+- `constraints/` – Timing, floorplanning, and synthesis constraint files.
+- `ip/` – External or third-party IP blocks integrated into the design.
+- `scripts/` – Utility scripts for build, lint, synthesis, and verification flows.
+- `docs/` – Project documentation, specifications, and onboarding material.
+
+## Getting Started
+
+1. Review `docs/environment_setup.md` for tool installation and environment configuration instructions.
+2. Populate the `rtl/` and `tb/` directories with your design sources and verification code.
+3. Capture project-specific processes, coding guidelines, and architecture notes under `docs/`.
+4. Track changes with Git and keep documentation up to date as the design evolves.
+
+## Contribution Guidelines
+
+See `CONTRIBUTING.md` for coding style conventions, commit message format, and review expectations.
+
+## License
+
+Add your preferred open-source or proprietary license in a `LICENSE` file before distributing the project.

--- a/constraints/README.md
+++ b/constraints/README.md
@@ -1,0 +1,9 @@
+# Constraints Directory
+
+Store timing, floorplanning, and synthesis constraint files in this directory. Organize files by tool or flow (e.g., `sdc/`, `xdc/`, `floorplan/`).
+
+## Recommendations
+
+- Keep constraint files under version control to ensure reproducible implementation results.
+- Document the target process technology and library versions referenced by each constraint set.
+- Update this README with instructions when multiple configurations or corners are supported.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,11 @@
+# Documentation Overview
+
+The documentation directory centralizes knowledge required to build, verify, and maintain the RV32 digital chip design. Use this space to keep project information synchronized with the implementation.
+
+## Contents
+
+- `architecture.md` – High-level design goals, block diagrams, and interface descriptions.
+- `environment_setup.md` – Toolchain, simulator, and dependency setup instructions.
+- `design_guidelines.md` – Coding conventions, naming rules, and best practices for RTL and verification code.
+
+Add additional documents as the project evolves. Update this index whenever you create new documentation to help contributors discover resources quickly.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,30 @@
+# Architecture Overview
+
+This document captures the high-level architecture of the RV32 digital chip design. Use it to describe the major functional blocks, their responsibilities, and their interfaces.
+
+## Design Goals
+
+- Provide a configurable 32-bit RISC-V pipeline suitable for embedded applications.
+- Balance performance, area, and power targets defined by the product requirements.
+- Maintain modularity to allow reuse of common subsystems.
+
+## Top-Level Block Diagram
+
+_Add a diagram or textual description of the top-level modules and their connections._
+
+## Core Components
+
+1. **Processor Core** – Outline pipeline stages, hazard management, and CSR support.
+2. **Instruction Fetch** – Describe memory hierarchy integration and prefetch strategies.
+3. **Execution Units** – Capture ALU, multiplier/divider, and other custom units.
+4. **Memory System** – Explain data cache, load/store unit, and memory interfaces.
+5. **Peripherals** – Enumerate integrated peripherals and communication buses.
+
+## Interface Specifications
+
+Document signal lists, protocols, and timing requirements for each module interface. Include references to industry standards when applicable.
+
+## Future Work
+
+- Track planned extensions such as custom instructions, security features, or debug modules.
+- Note architectural assumptions that must be validated through verification or implementation feedback.

--- a/docs/design_guidelines.md
+++ b/docs/design_guidelines.md
@@ -1,0 +1,29 @@
+# Design Guidelines
+
+These guidelines encourage consistency and maintainability across RTL and verification code in the RV32 repository.
+
+## General Principles
+
+- Write clear, synthesizable SystemVerilog or Verilog with meaningful hierarchy boundaries.
+- Prefer parameterization for reusable modules and to avoid magic numbers.
+- Document assumptions and corner cases near the relevant code.
+
+## RTL Coding Style
+
+- Use `lower_snake_case` for signal names and `UpperCamelCase` for module names.
+- Group related logic into `always_ff` and `always_comb` blocks.
+- Reset signals synchronously unless design requirements dictate otherwise.
+- Include assertions where possible to capture protocol expectations.
+
+## Testbench Practices
+
+- Develop self-checking testbenches with clear pass/fail criteria.
+- Separate stimulus generation, scoreboard, and coverage components.
+- Log important events to aid in debugging regressions.
+
+## Version Control
+
+- Commit generated files only if they are required for downstream tools.
+- Use `.gitignore` entries to exclude build artifacts and simulation outputs.
+
+Update these guidelines as the team aligns on detailed coding standards.

--- a/docs/environment_setup.md
+++ b/docs/environment_setup.md
@@ -1,0 +1,38 @@
+# Environment Setup
+
+Follow these steps to configure your workstation for RV32 digital chip development.
+
+## Prerequisites
+
+- Linux distribution or WSL2 environment with build-essential packages
+- Git, Python 3.8+, and make
+- Preferred text editor or IDE with SystemVerilog support
+
+## Toolchain
+
+1. Install a RISC-V GCC toolchain for compiling firmware and diagnostic tests.
+2. Set up a simulator such as Verilator, Questa, Xcelium, or VCS.
+3. Install synthesis and static timing analysis tools according to your organization's licensing agreements.
+
+## Python Environment
+
+```bash
+python3 -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt  # Add this file when Python utilities are introduced
+```
+
+## Environment Variables
+
+- `RV32_REPO_ROOT` – Path to this repository.
+- `RV32_TOOLCHAIN` – Root directory of the installed RISC-V toolchain.
+- `RV32_SIMULATOR` – Path to the primary simulation executable.
+
+Add the export commands to your shell profile for convenience.
+
+## Verification Infrastructure
+
+- Configure waveform viewers and log directories under `sim/`.
+- Document regression execution steps in `sim/README.md`.
+
+Keep this document current as tools are added or upgraded.

--- a/ip/README.md
+++ b/ip/README.md
@@ -1,0 +1,11 @@
+# Third-Party IP Directory
+
+Use this directory to track external IP cores integrated into the RV32 design.
+
+## Usage
+
+- Document licensing terms and version information for each imported IP block.
+- Maintain integration notes, including wrappers or adapters required for compatibility.
+- Store any configuration scripts or parameter files associated with the IP.
+
+If redistribution is restricted, include placeholders or instructions for obtaining the IP separately.

--- a/rtl/README.md
+++ b/rtl/README.md
@@ -1,0 +1,11 @@
+# RTL Source Directory
+
+Place synthesizable SystemVerilog or Verilog modules for the RV32 design in this directory. Organize submodules into subfolders as needed (e.g., `core/`, `memory/`, `peripherals/`).
+
+## Guidelines
+
+- Keep module interfaces documented using comments or separate markdown files.
+- Provide default parameter values and describe configuration options.
+- Include assertions or cover properties to help detect protocol violations early.
+
+Remember to update `docs/architecture.md` when significant RTL changes are introduced.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,11 @@
+# Scripts Directory
+
+Place reusable automation scripts for simulation, linting, synthesis, and verification flows here.
+
+## Best Practices
+
+- Provide a short usage description at the top of each script.
+- Keep scripts parameterized and avoid hard-coded absolute paths.
+- Capture dependencies such as Python packages in `requirements.txt` or equivalent files.
+
+Document complex flows directly in this README or link to detailed guides under `docs/`.

--- a/sim/README.md
+++ b/sim/README.md
@@ -1,0 +1,17 @@
+# Simulation Assets
+
+Use this directory to organize simulation run scripts, configuration files, and regression infrastructure.
+
+## Contents
+
+- `waves/` – Waveform configuration files for viewers like GTKWave or DVE.
+- `runs/` – Example run directories with Makefiles or launch scripts.
+- `logs/` – Collected log files from regressions (can be excluded from version control).
+
+## Usage
+
+1. Document simulator command-line options and environment variables here.
+2. Provide step-by-step instructions for running smoke tests and full regressions.
+3. Capture tips for debugging failures, including waveform capture settings and log filtering commands.
+
+Keep this README synchronized with actual flows to reduce onboarding time for new contributors.

--- a/tb/README.md
+++ b/tb/README.md
@@ -1,0 +1,15 @@
+# Testbench Directory
+
+This directory stores verification code, reference models, and coverage infrastructure for the RV32 design.
+
+## Suggested Structure
+
+- `unit/` – Block-level testbenches targeting individual modules.
+- `system/` – Chip-level testbenches with bus functional models and firmware images.
+- `uvm/` – UVM components, sequences, and configuration files (if applicable).
+
+## Best Practices
+
+- Strive for self-checking tests with clear pass/fail reporting.
+- Document how to run simulations and regressions in `sim/README.md`.
+- Version control only the sources and configurations required to reproduce results.


### PR DESCRIPTION
## Summary
- establish directory structure for RTL, verification, simulation, constraints, scripts, and IP assets
- add repository documentation including project overview, architecture, environment setup, and design guidelines
- provide contributing instructions and a default .gitignore tuned for hardware development flows

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68cd45e0e330832ca1d9ee172fa53a72